### PR TITLE
Add initial node list if bootstrapping is enabled via env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 FROM golang:1.17-alpine AS builder
 
-WORKDIR /go/src/github.com/seeruk/tsns
+WORKDIR /go/src/github.com/tigrisdata/tsns
 
 ADD . .
 
 RUN set -euxo pipefail \
- && go mod download \
- && CGO_ENABLED=0 go build -ldflags "-s -w" -o tsns .
+    && go mod download \
+    && CGO_ENABLED=0 go build -ldflags "-s -w" -o tsns .
 
 # Run steps
 FROM alpine:3
 
-COPY --from=builder /go/src/github.com/seeruk/tsns/tsns /opt
+COPY --from=builder /go/src/github.com/tigrisdata/tsns/tsns /opt
 
 RUN mkdir -p /usr/share/typesense
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/seeruk/tsns
+module github.com/tigrisdata/tsns
 
 go 1.17
 


### PR DESCRIPTION
Seeds the nodelist with a string that is passed down via a bootstrap environment variable, `INITIAL_NODELIST` in this case.

This only works if no health nodes are found and bootstrapping has been explicitly enabled with above variable.